### PR TITLE
Fix collection name in Cloud Function

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -64,7 +64,8 @@ export const lancarAbate = functions.https.onCall(async (request: functions.http
       status: "Aguardando Processamento",
     });
 
-    const contaPagarRef = db.collection("contas_a_pagar").doc();
+    // Correção: nome da coleção atualizado para seguir o padrão camelCase
+    const contaPagarRef = db.collection("contasAPagar").doc();
     batch.set(contaPagarRef, {
       abateId: abateRef.id,
       fornecedorId: fornecedorId,


### PR DESCRIPTION
## Summary
- fix Firestore collection name in `lancarAbate` function

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: missing script)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68857c4e2de8832585969af9a962036e